### PR TITLE
Use hard-coded container names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,13 @@ version: '2'
 
 services:
   spid-testenv-identityserver:
+    container_name: spid-testenv-identityserver
     build: identity-server/
     ports:
       - "9443:9443"
 
   spid-testenv-backoffice:
+    container_name: spid-testenv-backoffice
     build: backoffice/
     ports:
       - "8080:8080"


### PR DESCRIPTION
The application relies on those container names for internal networking, so we should hard-code them. Omitting the `container_name` option will leave naming to docker-compose, which might be different from what we expect (i.e. this happened to me when running `docker-compose up --force-recreate`).